### PR TITLE
Added quick fronted fix for displaying sensitive data when logged out.

### DIFF
--- a/src/components/core/PersonDocumentContributionList.vue
+++ b/src/components/core/PersonDocumentContributionList.vue
@@ -7,7 +7,7 @@
             <h4 v-else>
                 <strong>{{ contribution.personName?.firstname + " " + contribution.personName?.otherName + " " + contribution.personName?.lastname + (contribution.isCorrespondingContributor ? ` (${$t("correspondingContributorLabel")})` : "") + ` - ${getTitleFromValueAutoLocale(contribution.contributionType)}` }}</strong>
             </h4>
-            <h5 v-if="contribution.contact?.contactEmail">
+            <h5 v-if="loginStore.userLoggedIn && contribution.contact?.contactEmail">
                 <strong>{{ `${$t("emailLabel")}: ${contribution.contact?.contactEmail}` }}</strong>
             </h5>
             <v-divider v-if="index < (contributionList ? contributionList.length : 1) - 1 " class="mt-10"></v-divider>
@@ -22,6 +22,7 @@ import { getTitleFromValueAutoLocale } from '@/i18n/documentContributionType';
 import type { PersonDocumentContribution } from '@/models/PublicationModel';
 import { VueDraggableNext } from 'vue-draggable-next'
 import DocumentPublicationService from '@/services/DocumentPublicationService';
+import { useLoginStore } from '@/stores/loginStore';
 
 
 export default defineComponent({
@@ -38,13 +39,17 @@ export default defineComponent({
         }
     },
     setup(props) {
+        const loginStore = useLoginStore();
+
         const reorderContributors = (event: any) => {
             if(event.moved.newIndex !== event.moved.oldIndex) {
                 DocumentPublicationService.reorderContribution(props.documentId as number, props.contributionList[event.moved.newIndex].id as number, event.moved.oldIndex + 1, event.moved.newIndex + 1);
             }
         };
 
-        return { getTitleFromValueAutoLocale, reorderContributors };
+        return { 
+            getTitleFromValueAutoLocale, reorderContributors, loginStore
+        };
     },
 });
 </script>

--- a/src/views/landingPages/OrgUnitLandingView.vue
+++ b/src/views/landingPages/OrgUnitLandingView.vue
@@ -58,10 +58,10 @@
                                         {{ $t("notYetSetMessage") }}
                                     </span>
                                 </div>
-                                <div>
+                                <div v-if="loginStore.userLoggedIn">
                                     {{ $t("phoneNumberLabel") }}:
                                 </div>
-                                <div class="response">
+                                <div v-if="loginStore.userLoggedIn" class="response">
                                     {{ organisationUnit?.contact?.phoneNumber ? organisationUnit?.contact?.phoneNumber : $t("notYetSetMessage") }}
                                 </div>
                                 <div>
@@ -229,6 +229,7 @@ import StatisticsService from '@/services/StatisticsService';
 import StatisticsView from '@/components/assessment/statistics/StatisticsView.vue';
 import EntityIndicatorService from '@/services/assessment/EntityIndicatorService';
 import { type EntityIndicatorResponse, StatisticsType } from '@/models/AssessmentModel';
+import { useLoginStore } from '@/stores/loginStore';
 
 
 export default defineComponent({
@@ -289,6 +290,8 @@ export default defineComponent({
         const totalSubUnits = ref<number>(0);
 
         const ouIndicators = ref<EntityIndicatorResponse[]>([]);
+
+        const loginStore = useLoginStore();
 
         onMounted(() => {
             OrganisationUnitService.canEdit(parseInt(currentRoute.params.id as string)).then((response) => {
@@ -526,7 +529,7 @@ export default defineComponent({
             subUnits, totalSubUnits, switchSubUnitsPage,
             alumni, totalAlumni, switchAlumniPage,
             OrganisationUnitUpdateForm, fetchEmployees,
-            ouIndicators, StatisticsType
+            ouIndicators, StatisticsType, loginStore
         };
 }})
 

--- a/src/views/landingPages/ResearcherLandingView.vue
+++ b/src/views/landingPages/ResearcherLandingView.vue
@@ -41,22 +41,22 @@
                                 <div class="response">
                                     <person-other-name-modal :preset-person="person" :read-only="!canEdit" @update="updateNames" @select-primary="selectPrimaryName"></person-other-name-modal>
                                 </div>
-                                <div v-if="personalInfo.localBirthDate">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.localBirthDate">
                                     {{ $t("birthdateLabel") }}:
                                 </div>
-                                <div v-if="personalInfo.localBirthDate" class="response">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.localBirthDate" class="response">
                                     {{ localiseDate(personalInfo.localBirthDate) }}
                                 </div>
-                                <div v-if="personalInfo.sex">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.sex">
                                     {{ $t("sexLabel") }}:
                                 </div>
-                                <div v-if="personalInfo.sex" class="response">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.sex" class="response">
                                     {{ getTitleFromValueAutoLocale(personalInfo.sex) }}
                                 </div>
-                                <div v-if="personalInfo.country">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.country">
                                     {{ $t("countryLabel") }}:
                                 </div>
-                                <div v-if="personalInfo.country" class="response">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.country" class="response">
                                     {{ personalInfo.country }}
                                 </div>
                                 <div>APVNT:</div>
@@ -90,34 +90,34 @@
                                 </div>
                             </v-col>
                             <v-col cols="6">
-                                <div v-if="personalInfo.streetAndNumber">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.streetAndNumber">
                                     {{ $t("streetAndNumberLabel") }}:
                                 </div>
-                                <div v-if="personalInfo.streetAndNumber" class="response">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.streetAndNumber" class="response">
                                     {{ personalInfo.streetAndNumber }}
                                 </div>
-                                <div v-if="personalInfo.city">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.city">
                                     {{ $t("cityLabel") }}:
                                 </div>
-                                <div v-if="personalInfo.city" class="response">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.city" class="response">
                                     {{ personalInfo.city }}
                                 </div>
-                                <div v-if="personalInfo.placeOfBirth">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.placeOfBirth">
                                     {{ $t("placeOfBirthLabel") }}:
                                 </div>
-                                <div v-if="personalInfo.placeOfBirth" class="response">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.placeOfBirth" class="response">
                                     {{ personalInfo.placeOfBirth }}
                                 </div>
-                                <div v-if="personalInfo.contact.contactEmail">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.contact.contactEmail">
                                     {{ $t("emailLabel") }}:
                                 </div>
-                                <div v-if="personalInfo.contact.contactEmail" class="response">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.contact.contactEmail" class="response">
                                     <identifier-link :identifier="personalInfo.contact.contactEmail" type="email"></identifier-link>
                                 </div>
-                                <div v-if="personalInfo.contact.phoneNumber">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.contact.phoneNumber">
                                     {{ $t("phoneNumberLabel") }}:
                                 </div>
-                                <div v-if="personalInfo.contact.phoneNumber" class="response">
+                                <div v-if="loginStore.userLoggedIn && personalInfo.contact.phoneNumber" class="response">
                                     {{ personalInfo.contact.phoneNumber }}
                                 </div>
                                 <div v-if="person?.personalInfo.uris && person.personalInfo.uris.length > 0">
@@ -274,6 +274,7 @@ import StatisticsService from '@/services/StatisticsService';
 import { type EntityIndicatorResponse, StatisticsType } from '@/models/AssessmentModel';
 import EntityIndicatorService from '@/services/assessment/EntityIndicatorService';
 import StatisticsView from '@/components/assessment/statistics/StatisticsView.vue';
+import { useLoginStore } from '@/stores/loginStore';
 
 
 export default defineComponent({
@@ -319,6 +320,8 @@ export default defineComponent({
         const canEdit = ref(false);
 
         const personIndicators = ref<EntityIndicatorResponse[]>([]);
+
+        const loginStore = useLoginStore();
 
         onMounted(() => {
             PersonService.canEdit(parseInt(currentRoute.params.id as string)).then((response) => {
@@ -552,7 +555,7 @@ export default defineComponent({
         };
 
         return {
-            researcherName, person, personalInfo, keywords,
+            researcherName, person, personalInfo, keywords, loginStore,
             biography, publications,  totalPublications, switchPage, searchKeyword,
             returnCurrentLocaleContent, canEdit, employments, education, memberships,
             addExpertiseOrSkillProof, updateExpertiseOrSkillProof, deleteExpertiseOrSkillProof,


### PR DESCRIPTION
## Description

Added sensitive data fix (backend PR solves the problem, this is just a "bandaid" and a simple failsafe).

## How should this be tested?

Browse the portal, sensitive data such as addresses, phone numbers, etc.. Should not be displayed.

## Checklist

-   [x] I have tested these changes locally
-   [x] I have added tests that cover these changes (if applicable)
-   [x] I have updated the documentation (if applicable)
-   [x] I have added or updated the necessary comments in the code
