### PR TITLE
Refactored persons/organisations tabs to use new add/remove endpoints

### DIFF
--- a/src/components/project/ProjectOrganisationsTab.vue
+++ b/src/components/project/ProjectOrganisationsTab.vue
@@ -29,7 +29,7 @@
         v-model="selectedMembers"
         :items="sortedMembers"
         :headers="headers"
-        item-value="orderNumber"
+        item-value="id"
         :show-select="canEdit"
         return-object
         :items-per-page-text="$t('itemsPerPageLabel')"
@@ -168,20 +168,25 @@
         :message="$t('confirmDeletionMessage')"
         :entity-names="selectedMembers.map(member => institutionName(member))"
         @continue="removeSelected" />
+
+    <toast v-model="snackbar" :message="snackbarMessage" />
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { MultilingualContent } from "@/models/Common";
+import type { AxiosError } from "axios";
+import type { ErrorResponse, MultilingualContent } from "@/models/Common";
 import type { OrganisationUnitProjectContribution } from "@/models/ProjectModel";
 import { OrganisationUnitProjectContributionType } from "@/models/ProjectModel";
+import ProjectService from "@/services/project/ProjectService";
 import LocalizedLink from "@/components/localization/LocalizedLink.vue";
 import MultilingualTextInput from "@/components/core/MultilingualTextInput.vue";
 import DatePicker from "@/components/core/DatePicker.vue";
 import UriInput from "@/components/core/UriInput.vue";
 import OrganisationUnitAutocompleteSearch from "@/components/organisationUnit/OrganisationUnitAutocompleteSearch.vue";
 import PersistentQuestionDialog from "@/components/core/comparators/PersistentQuestionDialog.vue";
+import Toast from "@/components/core/Toast.vue";
 import {
     getOrganisationUnitProjectContributionTypeTitleFromValueAutoLocale,
     getOrganisationUnitProjectContributionTypesForGivenLocale
@@ -192,14 +197,15 @@ import { localiseDate } from "@/utils/DateUtil";
 import { useValidationUtils } from "@/utils/ValidationUtils";
 
 const props = withDefaults(defineProps<{
-    consortium: OrganisationUnitProjectContribution[];
+    projectId: number;
+    organisations: OrganisationUnitProjectContribution[];
     canEdit?: boolean;
 }>(), {
     canEdit: false
 });
 
 const emit = defineEmits<{
-    (e: "update", payload: OrganisationUnitProjectContribution[]): void;
+    (e: "refresh"): void;
 }>();
 
 const i18n = useI18n();
@@ -210,6 +216,8 @@ const selectedMembers = ref<OrganisationUnitProjectContribution[]>([]);
 const addDialog = ref(false);
 const displayPersistentDialog = ref(false);
 const isFormValid = ref(false);
+const snackbar = ref(false);
+const snackbarMessage = ref("");
 
 const externalOUNameRef = ref<typeof MultilingualTextInput>();
 const contributionDescriptionRef = ref<typeof MultilingualTextInput>();
@@ -234,8 +242,12 @@ const headers = computed(() => [
 const contributionTypes = computed(() => getOrganisationUnitProjectContributionTypesForGivenLocale());
 
 const sortedMembers = computed(() =>
-    [...props.consortium].sort((a, b) => a.orderNumber - b.orderNumber)
+    [...props.organisations].sort((a, b) => a.orderNumber - b.orderNumber)
 );
+
+watch(() => props.organisations, () => {
+    selectedMembers.value = [];
+});
 
 const institutionName = (member: OrganisationUnitProjectContribution) => {
     const name = member.organisationUnitId ?
@@ -266,26 +278,61 @@ const closeAddDialog = () => {
     contributionDescriptionRef.value?.clearInput();
 };
 
+const nextOrderNumber = () =>
+    props.organisations.reduce((highest, member) => Math.max(highest, member.orderNumber ?? 0), 0) + 1;
+
 const addInstitution = () => {
+    if (!enterExternalOU.value && selectedOrganisationUnit.value.value <= 0) {
+        return;
+    }
+
     const newMember: OrganisationUnitProjectContribution = {
         organisationUnitId: enterExternalOU.value ? undefined : selectedOrganisationUnit.value.value,
         displayOrganisationUnit: enterExternalOU.value ? externalOUName.value : [],
         contributionDescription: contributionDescription.value,
         contributionType: selectedContributionType.value?.value as OrganisationUnitProjectContributionType,
-        orderNumber: props.consortium.length + 1,
+        orderNumber: nextOrderNumber(),
         dateFrom: dateFrom.value ? dateFrom.value : undefined,
         dateTo: dateTo.value ? dateTo.value : undefined,
         uris: uris.value,
         fundingParts: []
     };
 
-    emit("update", [...props.consortium, newMember]);
-    closeAddDialog();
+    ProjectService.addProjectOrganisation(props.projectId, newMember).then(() => {
+        notify(i18n.t("savedMessage"));
+        closeAddDialog();
+        emit("refresh");
+    }).catch((error: AxiosError<ErrorResponse>) => {
+        notifyError(error);
+    });
 };
 
 const removeSelected = () => {
-    const remaining = props.consortium.filter(member => !selectedMembers.value.includes(member));
-    selectedMembers.value = [];
-    emit("update", remaining.map((member, index) => ({ ...member, orderNumber: index + 1 })));
+    const removedIds = selectedMembers.value
+        .map(member => member.id)
+        .filter((contributionId): contributionId is number => contributionId !== undefined);
+
+    Promise.all(removedIds.map(contributionId =>
+        ProjectService.removeProjectOrganisation(props.projectId, contributionId)
+    )).then(() => {
+        selectedMembers.value = [];
+        notify(i18n.t("updatedSuccessMessage"));
+        emit("refresh");
+    }).catch((error: AxiosError<ErrorResponse>) => {
+        selectedMembers.value = [];
+        notifyError(error);
+        emit("refresh");
+    });
+};
+
+const notify = (message: string) => {
+    snackbarMessage.value = message;
+    snackbar.value = true;
+};
+
+const notifyError = (error: AxiosError<ErrorResponse>) => {
+    const backendMessage = error.response?.data.message as string;
+    const translated = backendMessage ? i18n.t(backendMessage) : "";
+    notify(translated && translated !== backendMessage ? translated : i18n.t("genericErrorMessage"));
 };
 </script>

--- a/src/components/project/ProjectPersonsTab.vue
+++ b/src/components/project/ProjectPersonsTab.vue
@@ -29,7 +29,7 @@
         v-model="selectedMembers"
         :items="sortedMembers"
         :headers="headers"
-        item-value="orderNumber"
+        item-value="id"
         :show-select="canEdit"
         return-object
         :items-per-page-text="$t('itemsPerPageLabel')"
@@ -121,16 +121,22 @@
         :message="$t('confirmDeletionMessage')"
         :entity-names="selectedMembers.map(member => memberName(member))"
         @continue="removeSelected" />
+
+    <toast v-model="snackbar" :message="snackbarMessage" />
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
+import type { AxiosError } from "axios";
+import type { ErrorResponse } from "@/models/Common";
 import type { PersonProjectContribution } from "@/models/ProjectModel";
 import { PersonProjectContributionType, PersonProjectInvestigationRole } from "@/models/ProjectModel";
 import { useI18n } from "vue-i18n";
+import ProjectService from "@/services/project/ProjectService";
 import LocalizedLink from "@/components/localization/LocalizedLink.vue";
 import PersonAutocompleteSearch from "@/components/person/PersonAutocompleteSearch.vue";
 import PersistentQuestionDialog from "@/components/core/comparators/PersistentQuestionDialog.vue";
+import Toast from "@/components/core/Toast.vue";
 import {
     getPersonProjectContributionTypeTitleFromValueAutoLocale,
     getPersonProjectContributionTypesForGivenLocale
@@ -144,14 +150,15 @@ import { displayTextOrPlaceholder } from "@/utils/StringUtil";
 import { useValidationUtils } from "@/utils/ValidationUtils";
 
 const props = withDefaults(defineProps<{
-    team: PersonProjectContribution[];
+    projectId: number;
+    persons: PersonProjectContribution[];
     canEdit?: boolean;
 }>(), {
     canEdit: false
 });
 
 const emit = defineEmits<{
-    (e: "update", payload: PersonProjectContribution[]): void;
+    (e: "refresh"): void;
 }>();
 
 const i18n = useI18n();
@@ -162,6 +169,8 @@ const selectedMembers = ref<PersonProjectContribution[]>([]);
 const addDialog = ref(false);
 const displayPersistentDialog = ref(false);
 const isFormValid = ref(false);
+const snackbar = ref(false);
+const snackbarMessage = ref("");
 
 const searchPlaceholder = { title: "", value: -1 };
 const selectedPerson = ref<{ title: string, value: number }>(searchPlaceholder);
@@ -179,8 +188,12 @@ const contributionTypes = computed(() => getPersonProjectContributionTypesForGiv
 const investigationRoles = computed(() => getPersonProjectInvestigationRolesForGivenLocale());
 
 const sortedMembers = computed(() =>
-    [...props.team].sort((a, b) => a.orderNumber - b.orderNumber)
+    [...props.persons].sort((a, b) => a.orderNumber - b.orderNumber)
 );
+
+watch(() => props.persons, () => {
+    selectedMembers.value = [];
+});
 
 const memberName = (member: PersonProjectContribution) => {
     const name = [
@@ -199,13 +212,19 @@ const closeAddDialog = () => {
     selectedInvestigationRole.value = undefined;
 };
 
+const nextOrderNumber = () =>
+    props.persons.reduce((highest, member) => Math.max(highest, member.orderNumber ?? 0), 0) + 1;
+
 const addTeamMember = () => {
+    if (selectedPerson.value.value <= 0) {
+        return;
+    }
+
     const newMember: PersonProjectContribution = {
         personId: selectedPerson.value.value,
-        personName: { firstname: "", otherName: "", lastname: "" },
         contributionDescription: [],
         displayAffiliationStatement: [],
-        orderNumber: props.team.length + 1,
+        orderNumber: nextOrderNumber(),
         contributionType: selectedContributionType.value?.value as PersonProjectContributionType,
         investigationRole: selectedInvestigationRole.value?.value as PersonProjectInvestigationRole,
         otherRoleDescription: [],
@@ -213,13 +232,41 @@ const addTeamMember = () => {
         researchAreasId: []
     };
 
-    emit("update", [...props.team, newMember]);
-    closeAddDialog();
+    ProjectService.addProjectPerson(props.projectId, newMember).then(() => {
+        notify(i18n.t("savedMessage"));
+        closeAddDialog();
+        emit("refresh");
+    }).catch((error: AxiosError<ErrorResponse>) => {
+        notifyError(error);
+    });
 };
 
 const removeSelected = () => {
-    const remaining = props.team.filter(member => !selectedMembers.value.includes(member));
-    selectedMembers.value = [];
-    emit("update", remaining.map((member, index) => ({ ...member, orderNumber: index + 1 })));
+    const removedIds = selectedMembers.value
+        .map(member => member.id)
+        .filter((contributionId): contributionId is number => contributionId !== undefined);
+
+    Promise.all(removedIds.map(contributionId =>
+        ProjectService.removeProjectPerson(props.projectId, contributionId)
+    )).then(() => {
+        selectedMembers.value = [];
+        notify(i18n.t("updatedSuccessMessage"));
+        emit("refresh");
+    }).catch((error: AxiosError<ErrorResponse>) => {
+        selectedMembers.value = [];
+        notifyError(error);
+        emit("refresh");
+    });
+};
+
+const notify = (message: string) => {
+    snackbarMessage.value = message;
+    snackbar.value = true;
+};
+
+const notifyError = (error: AxiosError<ErrorResponse>) => {
+    const backendMessage = error.response?.data.message as string;
+    const translated = backendMessage ? i18n.t(backendMessage) : "";
+    notify(translated && translated !== backendMessage ? translated : i18n.t("genericErrorMessage"));
 };
 </script>

--- a/src/components/project/ProjectSubmissionForm.vue
+++ b/src/components/project/ProjectSubmissionForm.vue
@@ -121,8 +121,8 @@
                 <v-row>
                     <v-col>
                         <organisation-unit-project-contribution-form
-                            ref="consortiumRef"
-                            @set-input="consortium = $event"
+                            ref="organisationsRef"
+                            @set-input="organisations = $event"
                         />
                     </v-col>
                 </v-row>
@@ -256,7 +256,7 @@ const urisRef = ref<InstanceType<typeof UriInput>>();
 const costsRef = ref<InstanceType<typeof MonetaryAmountInput>>();
 const relationsRef = ref<InstanceType<typeof ProjectsRelationForm>>();
 const personsRef = ref<InstanceType<typeof PersonProjectContributionForm>>();
-const consortiumRef = ref<InstanceType<typeof OrganisationUnitProjectContributionForm>>();
+const organisationsRef = ref<InstanceType<typeof OrganisationUnitProjectContributionForm>>();
 
 const name = ref<MultilingualContent[]>([]);
 const nameAbbreviation = ref<MultilingualContent[]>([]);
@@ -271,7 +271,7 @@ const notFunded = ref(false);
 const costs = ref<MonetaryAmount | undefined>(undefined);
 const relations = ref<ProjectsRelation[]>([]);
 const persons = ref<PersonProjectContribution[]>([]);
-const consortium = ref<OrganisationUnitProjectContribution[]>([]);
+const organisations = ref<OrganisationUnitProjectContribution[]>([]);
 
 const status = ref<ProjectStatus>();
 const collaborationType = ref<ProjectCollaborationType>();
@@ -366,7 +366,7 @@ const submitProject = (stayOnPage: boolean) => {
         oldIds: [],
         mergedIds: [],
         researchAreasId: [],
-        consortium: consortium.value,
+        organisations: organisations.value,
         persons: persons.value,
         relations: relations.value,
     };
@@ -391,8 +391,8 @@ const submitProject = (stayOnPage: boolean) => {
             relationsRef.value?.clearInput();
             persons.value = [];
             personsRef.value?.clearInput();
-            consortium.value = [];
-            consortiumRef.value?.clearInput();
+            organisations.value = [];
+            organisationsRef.value?.clearInput();
             status.value = undefined;
             collaborationType.value = undefined;
             researchType.value = undefined;

--- a/src/models/ProjectModel.ts
+++ b/src/models/ProjectModel.ts
@@ -24,7 +24,7 @@ export interface Project {
     notFunded?: boolean;
     costs?: MonetaryAmount;
     persons: PersonProjectContribution[];
-    consortium: OrganisationUnitProjectContribution[];
+    organisations: OrganisationUnitProjectContribution[];
     relations: ProjectsRelation[];
 }
 

--- a/src/services/project/ProjectService.ts
+++ b/src/services/project/ProjectService.ts
@@ -1,6 +1,6 @@
 import { BaseService } from "@/services/BaseService";
 import axios, { type AxiosResponse } from "axios";
-import type { Project, ProjectDocument, ProjectEvent, ProjectIndex, ProjectStatus } from "@/models/ProjectModel";
+import type { OrganisationUnitProjectContribution, PersonProjectContribution, Project, ProjectDocument, ProjectEvent, ProjectIndex, ProjectStatus } from "@/models/ProjectModel";
 import type { Page } from "@/models/Common";
 
 export class ProjectService extends BaseService {
@@ -44,6 +44,22 @@ export class ProjectService extends BaseService {
 
     async canEdit(projectId: number): Promise<AxiosResponse<boolean>> {
         return super.sendRequest(axios.get, `project/${projectId}/can-edit`);
+    }
+
+    async addProjectPerson(projectId: number, personContribution: PersonProjectContribution): Promise<AxiosResponse<PersonProjectContribution>> {
+        return super.sendRequest(axios.post, `project/${projectId}/add-person`, personContribution, ProjectService.idempotencyKey);
+    }
+
+    async removeProjectPerson(projectId: number, personContributionId: number): Promise<AxiosResponse<void>> {
+        return super.sendRequest(axios.delete, `project/${projectId}/remove-person/${personContributionId}`);
+    }
+
+    async addProjectOrganisation(projectId: number, organisationContribution: OrganisationUnitProjectContribution): Promise<AxiosResponse<OrganisationUnitProjectContribution>> {
+        return super.sendRequest(axios.post, `project/${projectId}/add-organisation`, organisationContribution, ProjectService.idempotencyKey);
+    }
+
+    async removeProjectOrganisation(projectId: number, organisationContributionId: number): Promise<AxiosResponse<void>> {
+        return super.sendRequest(axios.delete, `project/${projectId}/remove-organisation/${organisationContributionId}`);
     }
 
     async readProjectDocuments(projectId: number): Promise<AxiosResponse<ProjectDocument[]>> {

--- a/src/views/landingPages/ProjectLandingView.vue
+++ b/src/views/landingPages/ProjectLandingView.vue
@@ -201,11 +201,12 @@
             <v-tabs-window-item value="team">
                 <v-row class="mt-10">
                     <v-col cols="12">
-                        <project-team-tab
-                            v-if="project"
-                            :team="project.persons ?? []"
+                        <project-persons-tab
+                            v-if="project?.id"
+                            :project-id="project.id"
+                            :persons="project.persons ?? []"
                             :can-edit="canEdit"
-                            @update="updateTeam"
+                            @refresh="fetchProject"
                         />
                     </v-col>
                 </v-row>
@@ -214,11 +215,12 @@
             <v-tabs-window-item value="consortium">
                 <v-row class="mt-10">
                     <v-col cols="12">
-                        <project-consortium-tab
-                            v-if="project"
-                            :consortium="project.consortium ?? []"
+                        <project-organisations-tab
+                            v-if="project?.id"
+                            :project-id="project.id"
+                            :organisations="project.organisations ?? []"
                             :can-edit="canEdit"
-                            @update="updateConsortium"
+                            @refresh="fetchProject"
                         />
                     </v-col>
                 </v-row>
@@ -318,8 +320,8 @@ import AlternateNameForm from "@/components/project/AlternateNameForm.vue";
 import ProjectUpdateForm from "@/components/project/ProjectUpdateForm.vue";
 import ProjectFundingsTab from "@/components/project/ProjectFundingsTab.vue";
 import ProjectFundingApplicationsTab from "@/components/project/ProjectFundingApplicationsTab.vue";
-import ProjectTeamTab from "@/components/project/ProjectTeamTab.vue";
-import ProjectConsortiumTab from "@/components/project/ProjectConsortiumTab.vue";
+import ProjectPersonsTab from "@/components/project/ProjectPersonsTab.vue";
+import ProjectOrganisationsTab from "@/components/project/ProjectOrganisationsTab.vue";
 import ProjectDocumentsTab from "@/components/project/ProjectDocumentsTab.vue";
 import ProjectEventsTab from "@/components/project/ProjectEventsTab.vue";
 import Toast from "@/components/core/Toast.vue";
@@ -354,7 +356,7 @@ const principleInvestigators = computed(() =>
 );
 
 const institutionCoordinators = computed(() =>
-    project.value?.consortium?.filter(
+    project.value?.organisations?.filter(
         institution => institution.contributionType === OrganisationUnitProjectContributionType.COORDINATOR
     ) ?? []
 );
@@ -416,16 +418,6 @@ const updateKeywords = (keywords: MultilingualContent[]) => {
 
 const updateDescription = (description: MultilingualContent[]) => {
     project.value!.description = description;
-    performUpdate(true);
-};
-
-const updateTeam = (team: PersonProjectContribution[]) => {
-    project.value!.persons = team;
-    performUpdate(true);
-};
-
-const updateConsortium = (consortium: OrganisationUnitProjectContribution[]) => {
-    project.value!.consortium = consortium;
     performUpdate(true);
 };
 


### PR DESCRIPTION
## Description

Follows the backend PR - the project landing page tabs were silent no-ops, since project update no longer touches collections.

- Renamed consortium $\rightarrow$ organisations across the model, submission form and landing page, matching the reworked ProjectDTO.
- ProjectTeamTab / ProjectConsortiumTab $\rightarrow$ ProjectPersonsTab / ProjectOrganisationsTab. Each tab now takes projectId, calls the new add-* / remove-* endpoints itself, and emits a single refresh instead of pushing a whole-project PUT. Removal goes by contribution id rather than object identity.
- Added the four service methods to ProjectService.

How should this be tested?

On a project landing page, add and remove a person and an institution - both should persist after a reload. Creating a project with institutions filled in should no longer drop them.

Checklist

- [x] I have tested these changes locally
- [x] I have added tests that cover these changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] I have added or updated the necessary comments in the code
